### PR TITLE
fix: trends endpoint serialization error (500)

### DIFF
--- a/services/api/app/api/analytics.py
+++ b/services/api/app/api/analytics.py
@@ -147,8 +147,19 @@ def get_message_trends(
     db: Session = Depends(get_db)
 ):
     """获取消息趋势分析"""
-    trends = crud.get_message_trends(db, days, interval)
-    return {"trends": trends}
+    try:
+        trends = crud.get_message_trends(db, days, interval)
+        return {
+            "trends": [
+                {"period": str(trend[0]), "count": trend[1]}
+                for trend in trends
+            ]
+        }
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"获取消息趋势失败: {str(e)}"
+        )
 
 @router.get("/content-analysis")
 def analyze_content(


### PR DESCRIPTION
## Problem

`GET /api/v1/analytics/trends` returns 500 Internal Server Error.

```
ValueError: [TypeError('cannot convert dictionary update sequence element #0 to a sequence'), TypeError('vars() argument must have __dict__ attribute')]
```

## Root Cause

`crud.get_message_trends()` returns SQLAlchemy Row objects containing a `datetime` period field. FastAPI's `jsonable_encoder` cannot serialize these Row objects directly.

## Fix

Manually convert Row objects to plain dicts:
```python
{"period": str(trend[0]), "count": trend[1]}
```

Also added try/except with proper error detail.

> Note: This fix was meant to be included in PR #23 but was pushed after merge. Sorry about that 🙏