### PR TITLE
config: change default API port to 8500

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,8 @@ MATRIX_PASSWORD=your_bot_password
 # Database Configuration (PostgreSQL)
 DATABASE_URL=postgresql://historian:historian@db:5432/historian
 
+# API Configuration
+API_PORT=8500
+
 # AI Analysis (Optional)
 GROQ_API_KEY=your_groq_api_key_here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       dockerfile: services/api/Dockerfile
     container_name: matrix-historian-api
     ports:
-      - "8000:8000"
+      - "${API_PORT:-8500}:8000"
     environment:
       - DATABASE_URL=postgresql://historian:historian@db:5432/historian
       - GROQ_API_KEY=${GROQ_API_KEY:-}


### PR DESCRIPTION
## Change

Default API port changed from 8000 to 8500 to avoid conflicts with other services (e.g. Vaultwarden).

Port is now configurable via `API_PORT` environment variable:
```yaml
ports:
  - "${API_PORT:-8500}:8000"
```

Set `API_PORT=9000` in `.env` to use a different port. Defaults to 8500 if not set.

## Files Changed
- `docker-compose.yml` — configurable port mapping
- `.env.example` — added API_PORT