### PR TITLE
feat: bot service healthcheck (non-HTTP)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,12 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "find /app/healthcheck -mmin -2 2>/dev/null || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
     restart: unless-stopped
     networks:
       - historian-network


### PR DESCRIPTION
## What

Adds a healthcheck to the bot service without requiring an HTTP server.

## How It Works

**Heartbeat file approach:**

1. Bot runs a background `asyncio` task that touches `/app/healthcheck` every 30 seconds
2. Docker healthcheck runs `find /app/healthcheck -mmin -2` — checks if the file was modified within 2 minutes
3. If the file goes stale → container marked unhealthy → Docker restarts it

**Why this is better than checking if the process is alive:**
- Process can be alive but the event loop might be blocked/deadlocked
- If the bot hangs (e.g. waiting on a stuck connection), the heartbeat stops, file goes stale, Docker restarts
- Simple, no extra dependencies, no HTTP server needed

## Config

```yaml
healthcheck:
  test: ["CMD-SHELL", "find /app/healthcheck -mmin -2 2>/dev/null || exit 1"]
  interval: 30s
  timeout: 5s
  retries: 3
  start_period: 60s  # give bot time to connect on first boot
```

## Files Changed
- `services/bot/app/bot.py` — added `_heartbeat_loop()` and integrated into `start()`
- `docker-compose.yml` — added healthcheck for bot service