### PR TITLE
fix: bot connection timeout for large accounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,8 @@ services:
       test: ["CMD-SHELL", "find /app/healthcheck -mmin -2 2>/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
-      retries: 3
-      start_period: 60s
+      retries: 5
+      start_period: 300s
     restart: unless-stopped
     networks:
       - historian-network


### PR DESCRIPTION
## Problem

Bot fails to connect with `TimeoutError` during initial sync when the account is in many rooms. Also leaves unclosed aiohttp sessions on reconnect.

```
bot - ERROR - Connection attempt failed: 
backoff - INFO - Backing off try_connect(...) for 0.8s (TimeoutError)
asyncio - ERROR - Unclosed client session
```

## Changes

1. **Increase sync timeout**: 65s → 300s (configurable via `MATRIX_SYNC_TIMEOUT` env var)
2. **Better retry**: max_tries 5→10, max_time 300s→600s, added `OSError` to retry exceptions
3. **Clean reconnect**: Close old client session before creating new one (fixes aiohttp warning)
4. **Healthcheck tolerance**: start_period 60s→300s for slow initial syncs

## Configuration

Set `MATRIX_SYNC_TIMEOUT=300000` (ms) in your environment to adjust. Default is 5 minutes which should handle accounts in 50+ rooms.