### PR TITLE
fix: decorator bug + volume shadowing code directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       minio:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "find /app/healthcheck -mmin -2 2>/dev/null || exit 1"]
+      test: ["CMD-SHELL", "find /app/data/healthcheck -mmin -2 2>/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 5
@@ -69,7 +69,7 @@ services:
     networks:
       - historian-network
     volumes:
-      - bot_sessions:/app
+      - bot_data:/app/data
 
   api:
     build:
@@ -103,7 +103,7 @@ services:
 volumes:
   postgres_data:
     driver: local
-  bot_sessions:
+  bot_data:
     driver: local
   minio_data:
     driver: local

--- a/services/bot/Dockerfile
+++ b/services/bot/Dockerfile
@@ -23,5 +23,8 @@ RUN uv pip install --system --no-cache -r requirements.txt
 
 COPY services/bot/app/ /app/
 
+# Create persistent data directory (mounted as volume at runtime)
+RUN mkdir -p /app/data
+
 # Run the bot
 CMD ["python", "main.py"]

--- a/services/bot/app/bot.py
+++ b/services/bot/app/bot.py
@@ -13,7 +13,7 @@ from nio import (
     RoomMessageVideo,
 )
 
-HEALTHCHECK_FILE = Path(os.getenv("HEALTHCHECK_FILE", "/app/healthcheck"))
+HEALTHCHECK_FILE = Path(os.getenv("HEALTHCHECK_FILE", "/app/data/healthcheck"))
 
 # Import from shared package
 import sys
@@ -53,7 +53,7 @@ class MatrixBot:
             homeserver=self.homeserver,
             username=self.username,
             password=self.password,
-            session_stored_file="bot_session.txt"
+            session_stored_file="/app/data/bot_session.txt"
         )
         self.config = botlib.Config()
         self.config.encryption_enabled = False
@@ -61,7 +61,7 @@ class MatrixBot:
         # when the bot is in many rooms)
         self.config.timeout = int(os.getenv("MATRIX_SYNC_TIMEOUT", "300000"))  # 5 minutes
         # Persist sync state so restarts only fetch incremental updates
-        self.config.store_path = os.getenv("MATRIX_STORE_PATH", "/app/nio_store")
+        self.config.store_path = os.getenv("MATRIX_STORE_PATH", "/app/data/nio_store")
         self.bot = botlib.Bot(self.creds, self.config)
         self.setup_handlers()
 


### PR DESCRIPTION
## Two fixes that didn't make it into PR #30

PR #30 was merged before these follow-up commits were pushed. This PR contains both remaining fixes.

---

### Fix 1: `handle_message` becomes `None` due to decorator

`on_message_event` doesn't return the decorated function, so using `@` syntax shadows `handle_message` with `None`. The media proxy callbacks then crash with:
```
TypeError: 'NoneType' object is not callable
```

**Fix:** Define `handle_message` first, then register explicitly:
```python
self.bot.listener.on_message_event(handle_message)
```

### Fix 2: Docker volume shadows entire code directory

`bot_sessions:/app` mounts a named volume over the entire working directory, so rebuilt images never update the running code.

**Fix:** Move persistent files (`bot_session.txt`, `nio_store`, `healthcheck`) into `/app/data/` and only mount `bot_data:/app/data`.

### Deploy notes
After merging, clean up the old volume:
```bash
docker compose down
docker volume rm matrix-historian_bot_sessions
docker compose up -d --build
```