### PR TITLE
fix: add missing src/lib/api.js — fixes Docker build failure

### DIFF
--- a/services/web/src/lib/api.js
+++ b/services/web/src/lib/api.js
@@ -1,0 +1,88 @@
+/**
+ * API client helpers for Matrix Historian web frontend.
+ * Each function hits the SvelteKit /api proxy which forwards to the backend.
+ */
+
+const BASE = '/api/v1';
+
+/**
+ * Tiny wrapper around fetch that throws on non-OK responses.
+ */
+async function request(path, params = {}, fetchFn = fetch) {
+	const url = new URL(path, 'http://localhost'); // URL only used for searchParams
+	for (const [k, v] of Object.entries(params)) {
+		if (v !== undefined && v !== null && v !== '') {
+			url.searchParams.set(k, String(v));
+		}
+	}
+	const qs = url.searchParams.toString();
+	const fullPath = qs ? `${path}?${qs}` : path;
+
+	const res = await fetchFn(fullPath);
+	if (!res.ok) {
+		throw new Error(`API ${res.status}: ${res.statusText}`);
+	}
+	return res.json();
+}
+
+// ─── Messages ───────────────────────────────────────────────────────
+
+export function getMessages(opts = {}, fetchFn = fetch) {
+	const { skip, limit, room_id, user_id } = opts;
+	return request(`${BASE}/messages/`, { skip, limit, room_id, user_id }, fetchFn);
+}
+
+export function getMessagesCount(opts = {}, fetchFn = fetch) {
+	const { room_id, user_id, query } = opts;
+	return request(`${BASE}/messages/count`, { room_id, user_id, query }, fetchFn);
+}
+
+export function searchMessages(query, opts = {}, fetchFn = fetch) {
+	const { skip, limit, room_id, user_id } = opts;
+	return request(`${BASE}/search/`, { query, skip, limit, room_id, user_id }, fetchFn);
+}
+
+// ─── Rooms ──────────────────────────────────────────────────────────
+
+export function getRooms(opts = {}, fetchFn = fetch) {
+	const { skip, limit } = opts;
+	return request(`${BASE}/rooms/`, { skip, limit }, fetchFn);
+}
+
+export function getRoomMessages(roomId, opts = {}, fetchFn = fetch) {
+	const { skip, limit } = opts;
+	return request(`${BASE}/rooms/${encodeURIComponent(roomId)}/messages`, { skip, limit }, fetchFn);
+}
+
+// ─── Users ──────────────────────────────────────────────────────────
+
+export function getUsers(opts = {}, fetchFn = fetch) {
+	const { skip, limit } = opts;
+	return request(`${BASE}/users/`, { skip, limit }, fetchFn);
+}
+
+export function getUserMessages(userId, opts = {}, fetchFn = fetch) {
+	const { skip, limit } = opts;
+	return request(`${BASE}/users/${encodeURIComponent(userId)}/messages`, { skip, limit }, fetchFn);
+}
+
+// ─── Media ──────────────────────────────────────────────────────────
+
+export function getMedia(opts = {}, fetchFn = fetch) {
+	const { skip, limit, mime_type } = opts;
+	return request(`${BASE}/media/`, { skip, limit, mime_type }, fetchFn);
+}
+
+// ─── Analytics ──────────────────────────────────────────────────────
+
+export function getMessageStats(days = 7, fetchFn = fetch) {
+	return request(`${BASE}/analytics/message-stats`, { days }, fetchFn);
+}
+
+export function getUserActivity(limit = 10, fetchFn = fetch) {
+	return request(`${BASE}/analytics/user-activity`, { limit }, fetchFn);
+}
+
+export function getRoomActivity(limit = 10, fetchFn = fetch) {
+	return request(`${BASE}/analytics/room-activity`, { limit }, fetchFn);
+}


### PR DESCRIPTION
## Problem

After merging PR #35, `docker-compose build web` fails at the `vite build` step:

```
Could not load /app/src/lib/api.js (imported by src/routes/+page.server.js): ENOENT
```

Every `+page.server.js` file imports helpers from `$lib/api.js`, but the file was never included in the PR.

**Root cause:** The root `.gitignore` contains `lib/` (intended for Python's lib directory), which also matches SvelteKit's `src/lib/` — so the file was silently excluded from git.

## Fix

Added `services/web/src/lib/api.js` with all the API client functions used by the server load functions:
- `getMessages`, `getMessagesCount`, `searchMessages`
- `getRooms`, `getRoomMessages`
- `getUsers`, `getUserMessages`
- `getMedia`
- `getMessageStats`, `getUserActivity`, `getRoomActivity`

Each function wraps a `fetch()` call to the corresponding `/api/v1/*` backend endpoint via the SvelteKit catch-all proxy.

## Follow-up suggestion

Consider changing `lib/` to `/lib/` in the root `.gitignore` so it only matches the top-level Python lib directory and doesn't accidentally ignore SvelteKit's `src/lib/`.