### PR TITLE
fix: scope lib/ in .gitignore to repo root only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/


### PR DESCRIPTION
## Problem

The root `.gitignore` has `lib/` which is meant for Python's top-level `lib/` directory, but the pattern matches **any** `lib/` at any depth — including SvelteKit's `src/lib/`.

This is the root cause of the build failure fixed in #36. Even though `api.js` was force-added, any new files added to `services/web/src/lib/` would be silently ignored again.

## Fix

```diff
-lib/
-lib64/
+/lib/
+/lib64/
```

The leading `/` anchors the pattern to the repository root, so it only matches `/lib/` and `/lib64/` at the top level. `src/lib/` (and any other nested `lib/` dirs) are no longer affected.