### PR TITLE
fix: add missing Chart.svelte component — fixes build

### DIFF
--- a/services/web/src/lib/Chart.svelte
+++ b/services/web/src/lib/Chart.svelte
@@ -1,0 +1,69 @@
+<script>
+	import { onMount, onDestroy } from 'svelte';
+	import {
+		Chart as ChartJS,
+		CategoryScale,
+		LinearScale,
+		BarElement,
+		LineElement,
+		PointElement,
+		ArcElement,
+		Filler,
+		Tooltip,
+		Legend
+	} from 'chart.js';
+
+	ChartJS.register(
+		CategoryScale,
+		LinearScale,
+		BarElement,
+		LineElement,
+		PointElement,
+		ArcElement,
+		Filler,
+		Tooltip,
+		Legend
+	);
+
+	let { type = 'bar', labels = [], datasets = [], options = {} } = $props();
+
+	let canvas;
+	let chart;
+
+	function buildConfig() {
+		return {
+			type,
+			data: { labels, datasets },
+			options: {
+				responsive: true,
+				maintainAspectRatio: false,
+				plugins: {
+					legend: { display: datasets.length > 1 }
+				},
+				...options
+			}
+		};
+	}
+
+	onMount(() => {
+		chart = new ChartJS(canvas, buildConfig());
+	});
+
+	onDestroy(() => {
+		chart?.destroy();
+	});
+
+	// Reactively update chart when data changes
+	$effect(() => {
+		if (chart) {
+			chart.data.labels = labels;
+			chart.data.datasets = datasets;
+			chart.options = { ...chart.options, ...options };
+			chart.update();
+		}
+	});
+</script>
+
+<div class="w-full h-64">
+	<canvas bind:this={canvas}></canvas>
+</div>


### PR DESCRIPTION
## Problem

After merging #36 and #37, the build now gets past `api.js` but fails on the next missing `$lib/` file:

```
Could not load /app/src/lib/Chart.svelte (imported by src/routes/analytics/+page.svelte): ENOENT
```

Same root cause — the old `lib/` gitignore pattern (fixed in #37) had prevented this file from being committed in the original PR #35.

## Fix

Added `services/web/src/lib/Chart.svelte` — a Svelte 5 wrapper around Chart.js that:
- Registers the needed Chart.js components (scales, elements, plugins)
- Accepts `type`, `labels`, `datasets`, and `options` props
- Reactively updates the chart when data changes via `$effect()`
- Cleans up on destroy

This should be the **last** missing `$lib/` file — I've checked all imports across the PR #35 files and only `api.js` (fixed in #36) and `Chart.svelte` (this PR) are referenced.