### PR TITLE
fix: resolve API 308 redirect issue

### DIFF
--- a/services/web/src/lib/api.js
+++ b/services/web/src/lib/api.js
@@ -9,14 +9,17 @@ const BASE = '/api/v1';
  * Tiny wrapper around fetch that throws on non-OK responses.
  */
 async function request(path, params = {}, fetchFn = fetch) {
-	const url = new URL(path, 'http://localhost'); // URL only used for searchParams
+	// Strip trailing slash to avoid SvelteKit 308 redirects (trailingSlash: 'never')
+	const cleanPath = path.endsWith('/') ? path.slice(0, -1) : path;
+
+	const url = new URL(cleanPath, 'http://localhost'); // URL only used for searchParams
 	for (const [k, v] of Object.entries(params)) {
 		if (v !== undefined && v !== null && v !== '') {
 			url.searchParams.set(k, String(v));
 		}
 	}
 	const qs = url.searchParams.toString();
-	const fullPath = qs ? `${path}?${qs}` : path;
+	const fullPath = qs ? `${cleanPath}?${qs}` : cleanPath;
 
 	const res = await fetchFn(fullPath);
 	if (!res.ok) {


### PR DESCRIPTION
## Problem

After the build succeeds, the app throws `API 308:` errors at runtime. This is a redirect loop between SvelteKit and FastAPI:

1. **SvelteKit** defaults to `trailingSlash: 'never'` — any internal fetch to `/api/v1/messages/` (with trailing slash) gets a **308 redirect** to `/api/v1/messages`
2. **FastAPI** defines routes with trailing slashes (`/messages/`) and **307 redirects** requests without them back to the slashed version

Result: redirect ping-pong 🏓

## Fix

**`src/lib/api.js`** — strip trailing slashes from all paths before calling fetch:
```js
const cleanPath = path.endsWith('/') ? path.slice(0, -1) : path;
```

**`src/routes/api/[...path]/+server.js`** — explicitly follow backend redirects so FastAPI's 307s are resolved transparently:
```js
redirect: 'follow'
```

Also strips the `Location` header from proxied responses to avoid confusing the client.