### PR TITLE
fix: API 500 on /analytics/message-stats — serialize SQLAlchemy Rows

### DIFF
--- a/services/api/app/api/analytics.py
+++ b/services/api/app/api/analytics.py
@@ -138,7 +138,16 @@ def get_user_interactions(
 ):
     """获取用户互动数据"""
     interactions = crud.get_user_interaction_pairs(db, days, min_count)
-    return {"interactions": interactions}
+    return {
+        "interactions": [
+            {
+                "room_id": row[0],
+                "sender_id": row[1],
+                "timestamp": row[2].isoformat() if hasattr(row[2], 'isoformat') else str(row[2])
+            }
+            for row in interactions
+        ]
+    }
 
 @router.get("/trends")
 def get_message_trends(

--- a/services/api/app/api/routes.py
+++ b/services/api/app/api/routes.py
@@ -121,7 +121,12 @@ def get_message_statistics(
 ):
     """获取消息统计数据"""
     stats = crud.get_message_stats(db, days)
-    return {"stats": stats}
+    return {
+        "stats": [
+            {"date": str(row.date), "count": row.count}
+            for row in stats
+        ]
+    }
 
 @router.get("/analytics/user-activity")
 def get_user_activity(


### PR DESCRIPTION
## Problem

`GET /api/v1/analytics/message-stats?days=14` returns **500 Internal Server Error**:

```
ValueError: [TypeError('cannot convert dictionary update sequence element #0 to a sequence'),
             TypeError('vars() argument must have __dict__ attribute')]
```

FastAPI's `jsonable_encoder` can't serialize raw SQLAlchemy Row objects.

## Root cause

`crud.get_message_stats()` returns a list of SQLAlchemy Row objects (named tuples with `.date` and `.count`), but the route handler passed them directly:

```python
# Before (broken)
return {"stats": stats}
```

Same issue with `/analytics/interactions` which returns raw `(room_id, sender_id, timestamp)` tuples.

## Fix

Explicitly convert Row objects to plain dicts before returning:

```python
# After (fixed)
return {
    "stats": [
        {"date": str(row.date), "count": row.count}
        for row in stats
    ]
}
```

**Files changed:** `routes.py` + `analytics.py` (2 endpoints fixed)