### PR TITLE
fix: analytics page not displaying data — field name mismatch

### DIFF
--- a/services/web/src/routes/analytics/+page.server.js
+++ b/services/web/src/routes/analytics/+page.server.js
@@ -1,14 +1,14 @@
 import {
 	getMessageStats, getUserActivity, getRoomActivity,
 	getAnalyticsOverview, getWordcloud, getActivityHeatmap,
-	getTrends, getInteractions, getContentAnalysis, getUserNetwork
+	getTrends, getInteractions, getMessagesCount, getRooms, getUsers
 } from '$lib/api.js';
 
 export async function load({ fetch, url }) {
 	const interval = url.searchParams.get('interval') || 'day';
 
 	try {
-		const [msgStats, userActivity, roomActivity, overview, wordcloud, heatmap, trends, interactions, contentAnalysis, userNetwork] = await Promise.all([
+		const [msgStats, userActivity, roomActivity, overview, wordcloud, heatmap, trends, interactions, countData, rooms, users] = await Promise.all([
 			getMessageStats(14, fetch).catch(() => ({ stats: [] })),
 			getUserActivity(10, fetch).catch(() => ({ users: [] })),
 			getRoomActivity(10, fetch).catch(() => ({ rooms: [] })),
@@ -17,33 +17,51 @@ export async function load({ fetch, url }) {
 			getActivityHeatmap(fetch).catch(() => ({ heatmap: [], weekdays: [], hours: [] })),
 			getTrends(interval, fetch).catch(() => ({ trends: [] })),
 			getInteractions(fetch).catch(() => ({ interactions: [] })),
-			getContentAnalysis(fetch).catch(() => ({ words: [] })),
-			getUserNetwork(fetch).catch(() => ({ nodes: [], edges: [] }))
+			getMessagesCount({}, fetch).catch(() => ({ total: 0 })),
+			getRooms({ limit: 1000 }, fetch).catch(() => []),
+			getUsers({ limit: 1000 }, fetch).catch(() => [])
 		]);
 
+		// Compute totals from count endpoint and list lengths
+		const totalMessages = countData.total ?? 0;
+		const totalRooms = Array.isArray(rooms) ? rooms.length : 0;
+		const totalUsers = Array.isArray(users) ? users.length : 0;
+
+		// Compute avg messages per day from message stats
+		const stats = msgStats.stats ?? [];
+		const avgPerDay = stats.length > 0
+			? Math.round(stats.reduce((sum, s) => sum + (s.count ?? s[1] ?? 0), 0) / stats.length)
+			: 0;
+
+		// Extract hourly activity from overview if available
+		const hourlyActivity = overview?.hourly_activity ?? [];
+
 		return {
-			messageStats: msgStats.stats ?? [],
+			messageStats: stats,
 			userActivity: userActivity.users ?? [],
 			roomActivity: roomActivity.rooms ?? [],
-			overview,
+			totalMessages,
+			totalRooms,
+			totalUsers,
+			avgPerDay,
+			hourlyActivity,
 			wordcloud: wordcloud.messages ?? wordcloud.words ?? [],
 			heatmap: heatmap.heatmap ?? [],
 			heatmapWeekdays: heatmap.weekdays ?? ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
 			heatmapHours: heatmap.hours ?? Array.from({ length: 24 }, (_, i) => i),
 			trends: trends.trends ?? [],
 			interval,
-			interactions: interactions.interactions ?? [],
-			contentAnalysis: contentAnalysis.words ?? [],
-			userNetwork
+			interactions: interactions.interactions ?? []
 		};
 	} catch (e) {
 		console.error('Analytics load error:', e);
 		return {
 			messageStats: [], userActivity: [], roomActivity: [],
-			overview: null, wordcloud: [], heatmap: [],
+			totalMessages: 0, totalRooms: 0, totalUsers: 0, avgPerDay: 0,
+			hourlyActivity: [],
+			wordcloud: [], heatmap: [],
 			heatmapWeekdays: [], heatmapHours: [],
 			trends: [], interval, interactions: [],
-			contentAnalysis: [], userNetwork: null,
 			error: e.message
 		};
 	}


### PR DESCRIPTION
## Problem

Analytics page shows empty/missing data even though the API returns correct responses. The frontend expected field names that don't match what the backend actually returns.

### Mismatches found:

| Frontend expected | API actually returns |
|---|---|
| `overview.total_messages` | Not in response (overview returns `message_stats`, `user_activity`, etc.) |
| `overview.total_rooms` | Not in response |
| `overview.total_users` | Not in response |
| `overview.avg_messages_per_day` | Not in response |
| `interactions[].user_a`, `user_b`, `count` | `room_id`, `sender_id`, `timestamp` |
| `contentAnalysis`, `userNetwork` | Requires AI module (500s silently) |

## Fix

**`+page.server.js`:**
- Fetches `/messages/count`, `/rooms`, `/users` separately for real totals
- Computes `avgPerDay` from the 14-day stats data
- Extracts `hourlyActivity` from overview correctly
- Removed `contentAnalysis`/`userNetwork` calls (depend on AI module)

**`+page.svelte`:**
- Overview stats always render (not gated on overview object existing)
- Uses correct field names: `totalMessages`, `totalRooms`, `totalUsers`, `avgPerDay`
- Fixed interactions table columns to match actual data
- Better date formatting in chart labels