### PR TITLE
feat(web): fix dashboard counts, animated counters & auto-refresh

### DIFF
--- a/services/web/src/lib/AnimatedCount.svelte
+++ b/services/web/src/lib/AnimatedCount.svelte
@@ -1,0 +1,47 @@
+<script>
+	/**
+	 * Animated number counter component
+	 * Smoothly counts up from 0 to the target value on mount/change
+	 */
+	let { value = 0, duration = 1200, formatFn } = $props();
+
+	let displayed = $state(0);
+	let animFrame = null;
+
+	function format(n) {
+		if (formatFn) return formatFn(n);
+		return Math.round(n).toLocaleString();
+	}
+
+	$effect(() => {
+		const target = Number(value) || 0;
+		const start = displayed;
+		const diff = target - start;
+		if (diff === 0) return;
+
+		const startTime = performance.now();
+
+		function tick(now) {
+			const elapsed = now - startTime;
+			const progress = Math.min(elapsed / duration, 1);
+			// ease-out cubic
+			const eased = 1 - Math.pow(1 - progress, 3);
+			displayed = start + diff * eased;
+
+			if (progress < 1) {
+				animFrame = requestAnimationFrame(tick);
+			} else {
+				displayed = target;
+			}
+		}
+
+		if (animFrame) cancelAnimationFrame(animFrame);
+		animFrame = requestAnimationFrame(tick);
+
+		return () => {
+			if (animFrame) cancelAnimationFrame(animFrame);
+		};
+	});
+</script>
+
+{format(displayed)}

--- a/services/web/src/routes/+page.server.js
+++ b/services/web/src/routes/+page.server.js
@@ -2,21 +2,23 @@ import { getMessagesCount, getRooms, getUsers, getMessages, getAnalyticsOverview
 
 export async function load({ fetch }) {
 	try {
-		const [countData, rooms, users, recent, overview] = await Promise.all([
+		const [countData, rooms, users, allRooms, allUsers, recent, overview] = await Promise.all([
 			getMessagesCount({}, fetch),
-			getRooms({ limit: 100 }, fetch),
-			getUsers({ limit: 100 }, fetch),
+			getRooms({ limit: 5 }, fetch),          // Top 5 for display
+			getUsers({ limit: 5 }, fetch),           // Top 5 for display
+			getRooms({ limit: 100000 }, fetch),      // All rooms for accurate count
+			getUsers({ limit: 100000 }, fetch),      // All users for accurate count
 			getMessages({ limit: 10 }, fetch),
 			getAnalyticsOverview(fetch).catch(() => null)
 		]);
 
 		return {
 			messageCount: countData.total ?? 0,
-			roomCount: rooms.length ?? 0,
-			userCount: users.length ?? 0,
+			roomCount: Array.isArray(allRooms) ? allRooms.length : 0,
+			userCount: Array.isArray(allUsers) ? allUsers.length : 0,
 			recentMessages: recent.messages ?? [],
-			rooms: rooms.slice(0, 5),
-			users: users.slice(0, 5),
+			rooms: Array.isArray(rooms) ? rooms.slice(0, 5) : [],
+			users: Array.isArray(users) ? users.slice(0, 5) : [],
 			overview
 		};
 	} catch (e) {

--- a/services/web/src/routes/+page.svelte
+++ b/services/web/src/routes/+page.svelte
@@ -1,14 +1,45 @@
 <script>
 	import Chart from '$lib/Chart.svelte';
+	import AnimatedCount from '$lib/AnimatedCount.svelte';
 	import { t } from '$lib/i18n';
 	import { formatTime } from '$lib/timezone';
+	import { getMessagesCount, getMessages, getUsers, getRooms } from '$lib/api.js';
+	import { onMount } from 'svelte';
 
 	let { data } = $props();
+
+	// Live-updating stats
+	let messageCount = $state(data.messageCount);
+	let roomCount = $state(data.roomCount);
+	let userCount = $state(data.userCount);
+	let recentMessages = $state(data.recentMessages);
 
 	// Hourly activity from overview
 	let hourlyActivity = $derived(data.overview?.hourly_activity ?? []);
 	let hourlyLabels = $derived(hourlyActivity.map((h) => `${String(h.hour ?? h[0] ?? '').padStart(2, '0')}:00`));
 	let hourlyCounts = $derived(hourlyActivity.map((h) => h.count ?? h[1] ?? 0));
+
+	// Auto-refresh every 30 seconds
+	onMount(() => {
+		const interval = setInterval(async () => {
+			try {
+				const [countData, recent, allRooms, allUsers] = await Promise.all([
+					getMessagesCount({}),
+					getMessages({ limit: 10 }),
+					getRooms({ limit: 100000 }),
+					getUsers({ limit: 100000 })
+				]);
+				messageCount = countData.total ?? messageCount;
+				roomCount = Array.isArray(allRooms) ? allRooms.length : roomCount;
+				userCount = Array.isArray(allUsers) ? allUsers.length : userCount;
+				if (recent.messages?.length > 0) {
+					recentMessages = recent.messages;
+				}
+			} catch {}
+		}, 30000);
+
+		return () => clearInterval(interval);
+	});
 </script>
 
 <svelte:head>
@@ -28,19 +59,19 @@
 	<a href="/messages" class="stat bg-base-200 rounded-box shadow hover:bg-base-300 transition-colors cursor-pointer">
 		<div class="stat-figure text-primary text-3xl">💬</div>
 		<div class="stat-title">{$t('dashboard.totalMessages')}</div>
-		<div class="stat-value text-primary">{data.messageCount.toLocaleString()}</div>
+		<div class="stat-value text-primary"><AnimatedCount value={messageCount} /></div>
 		<div class="stat-desc">{$t('dashboard.viewMessages')}</div>
 	</a>
 	<a href="/rooms" class="stat bg-base-200 rounded-box shadow hover:bg-base-300 transition-colors cursor-pointer">
 		<div class="stat-figure text-secondary text-3xl">🏠</div>
 		<div class="stat-title">{$t('dashboard.rooms')}</div>
-		<div class="stat-value text-secondary">{data.roomCount}</div>
+		<div class="stat-value text-secondary"><AnimatedCount value={roomCount} /></div>
 		<div class="stat-desc">{$t('dashboard.browseRooms')}</div>
 	</a>
 	<a href="/users" class="stat bg-base-200 rounded-box shadow hover:bg-base-300 transition-colors cursor-pointer">
 		<div class="stat-figure text-accent text-3xl">👥</div>
 		<div class="stat-title">{$t('dashboard.users')}</div>
-		<div class="stat-value text-accent">{data.userCount}</div>
+		<div class="stat-value text-accent"><AnimatedCount value={userCount} /></div>
 		<div class="stat-desc">{$t('dashboard.viewUsers')}</div>
 	</a>
 </div>
@@ -82,11 +113,11 @@
 				<a href="/messages" class="btn btn-ghost btn-xs">{$t('common.viewAll')}</a>
 			</div>
 
-			{#if data.recentMessages.length === 0}
+			{#if recentMessages.length === 0}
 				<p class="opacity-60">{$t('dashboard.noMessages')}</p>
 			{:else}
 				<div class="space-y-2 max-h-96 overflow-y-auto">
-					{#each data.recentMessages as msg}
+					{#each recentMessages as msg}
 						<div class="chat chat-start">
 							<div class="chat-header">
 								<a href="/users/{encodeURIComponent(msg.sender_id)}" class="link link-hover font-medium text-sm">

--- a/services/web/src/routes/analytics/+page.server.js
+++ b/services/web/src/routes/analytics/+page.server.js
@@ -19,8 +19,8 @@ export async function load({ fetch, url }) {
 			getTrends(interval, fetch).catch(() => ({ trends: [] })),
 			getInteractions(fetch).catch(() => ({ interactions: [] })),
 			getMessagesCount({}, fetch).catch(() => ({ total: 0 })),
-			getRooms({ limit: 1000 }, fetch).catch(() => []),
-			getUsers({ limit: 1000 }, fetch).catch(() => []),
+			getRooms({ limit: 100000 }, fetch).catch(() => []),
+			getUsers({ limit: 100000 }, fetch).catch(() => []),
 			getUserHourlyActivity({ days: 7, limit: 10 }, fetch).catch(() => ({ users: [], hours: [], days: 7, user_count: 0 }))
 		]);
 


### PR DESCRIPTION
## Fixes

### User/Room count showing 100 instead of actual count
The dashboard was calling `getUsers({ limit: 100 })` and using `users.length` as the total count — so it always capped at 100. Now fetches without artificial limit for accurate counts. Same fix applied to the analytics page.

> **Note:** A proper `/users/count` and `/rooms/count` API endpoint would be more efficient. Current workaround fetches all records just for counting.

## New Features

### Animated Counters
- New `AnimatedCount` component with smooth ease-out cubic animation
- Stats cards (messages, rooms, users) animate from 0 to their value on page load
- When values change (via auto-refresh), they smoothly animate to the new number

### Auto-Refresh Dashboard
- Dashboard polls the API every 30 seconds for:
  - Message count
  - Recent messages
  - Room count  
  - User count
- Updates are seamless — no page reload, counters animate to new values
- Errors during refresh are silently caught (no UI disruption)

## Files Changed
- `src/lib/AnimatedCount.svelte` — new animated number component
- `src/routes/+page.server.js` — fix count limits
- `src/routes/+page.svelte` — animated counters + auto-refresh
- `src/routes/analytics/+page.server.js` — fix count limits

## About Telegram bridged usernames
This is not addressed in this PR as it would require backend changes to parse `telegram_*` user IDs and resolve display names from the bridge. Can be tackled separately.