### PR TITLE
fix(web): normalize UTC timestamps + reduce refresh to 5s

### DIFF
--- a/services/web/src/lib/timezone.js
+++ b/services/web/src/lib/timezone.js
@@ -23,12 +23,27 @@ export function setTimezone(tz) {
 }
 
 /**
+ * Normalize bare ISO timestamps from the API by appending 'Z' if missing.
+ * The backend stores and returns UTC timestamps but without the 'Z' suffix
+ * (e.g. "2026-03-14T13:44:48.472716"). Without 'Z', JS Date() treats them
+ * as local time, causing incorrect timezone conversions.
+ */
+function normalizeUtcTimestamp(timestamp) {
+	const s = String(timestamp);
+	if (/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/.test(s) && !/[Zz]|[+-]\d{2}/.test(s)) {
+		return s + 'Z';
+	}
+	return s;
+}
+
+/**
  * Derived store: $formatTime(timestamp) returns localized date/time string
  */
 export const formatTime = derived(timezone, ($tz) => {
 	return (timestamp) => {
 		if (!timestamp) return '';
-		const d = new Date(timestamp);
+		const normalized = normalizeUtcTimestamp(timestamp);
+		const d = new Date(normalized);
 		if (isNaN(d.getTime())) return String(timestamp);
 		const options = {
 			year: 'numeric',
@@ -46,3 +61,6 @@ export const formatTime = derived(timezone, ($tz) => {
 		return d.toLocaleString(undefined, options);
 	};
 });
+
+/** Export for use in analytics chart labels */
+export { normalizeUtcTimestamp };

--- a/services/web/src/routes/+page.svelte
+++ b/services/web/src/routes/+page.svelte
@@ -36,7 +36,7 @@
 					recentMessages = recent.messages;
 				}
 			} catch {}
-		}, 30000);
+		}, 5000);
 
 		return () => clearInterval(interval);
 	});

--- a/services/web/src/routes/analytics/+page.svelte
+++ b/services/web/src/routes/analytics/+page.svelte
@@ -2,17 +2,20 @@
 	import Chart from '$lib/Chart.svelte';
 	import { goto } from '$app/navigation';
 	import { t } from '$lib/i18n';
+	import { formatTime, normalizeUtcTimestamp } from '$lib/timezone';
 
 	let { data } = $props();
 
-	// Message trend chart data (14-day stats) — API returns {date, count} objects
-	let trendLabels = $derived(data.messageStats.map((s) => {
-		const raw = s.date ?? s[0] ?? '';
+	/** Format a date string as a short M/D label, normalizing UTC timestamps */
+	function formatDateLabel(raw) {
 		try {
-			const d = new Date(raw);
+			const d = new Date(normalizeUtcTimestamp(raw));
 			return isNaN(d) ? String(raw) : `${d.getMonth() + 1}/${d.getDate()}`;
 		} catch { return String(raw); }
-	}));
+	}
+
+	// Message trend chart data (14-day stats) — API returns {date, count} objects
+	let trendLabels = $derived(data.messageStats.map((s) => formatDateLabel(s.date ?? s[0] ?? '')));
 	let trendCounts = $derived(data.messageStats.map((s) => s.count ?? s[1] ?? 0));
 
 	// User activity chart data
@@ -28,13 +31,7 @@
 	let hourlyCounts = $derived((data.hourlyActivity ?? []).map((h) => h.count ?? h[1] ?? 0));
 
 	// Trends with interval
-	let trendsLabels = $derived(data.trends.map((t) => {
-		const raw = t.period ?? t.date ?? t[0] ?? '';
-		try {
-			const d = new Date(raw);
-			return isNaN(d) ? String(raw) : `${d.getMonth() + 1}/${d.getDate()}`;
-		} catch { return String(raw); }
-	}));
+	let trendsLabels = $derived(data.trends.map((t) => formatDateLabel(t.period ?? t.date ?? t[0] ?? '')));
 	let trendsTotals = $derived(data.trends.map((t) => t.count ?? t.total ?? t[1] ?? 0));
 
 	// Word cloud
@@ -366,7 +363,7 @@
 								<tr>
 									<td class="text-xs">{row.room_id ?? ''}</td>
 									<td class="text-xs">{row.sender_id ?? ''}</td>
-									<td class="text-xs opacity-60">{row.timestamp ?? ''}</td>
+									<td class="text-xs opacity-60">{row.timestamp ? $formatTime(row.timestamp) : ''}</td>
 								</tr>
 							{/each}
 						</tbody>


### PR DESCRIPTION
## Timezone Fix

Previous PR's timestamp fix was lost during merge. This properly fixes UTC timestamp handling.

**Root cause:** API returns timestamps like `2026-03-14T13:44:48.472716` without `Z` suffix. JavaScript's `new Date()` treats bare ISO strings as **local time**, not UTC. In a UTC+8 browser, UTC 13:00 was incorrectly displayed as UTC 05:00.

**Fix:** `normalizeUtcTimestamp()` detects bare ISO timestamps and appends `Z` before parsing.

**Applied to:**
- `timezone.js` — `formatTime()` now normalizes before parsing (affects all message timestamps)
- `analytics/+page.svelte` — chart date labels use normalized timestamps
- `analytics/+page.svelte` — User Interactions table now uses `$formatTime()` instead of raw timestamp

## Refresh Interval
- Changed dashboard auto-refresh from 30s → 5s

## Files Changed
- `src/lib/timezone.js` — add `normalizeUtcTimestamp()` + export
- `src/routes/+page.svelte` — 30s → 5s interval
- `src/routes/analytics/+page.svelte` — normalized date labels + formatTime for interactions