### PR TITLE
fix(web): SSR hydration causing wrong timezone display

### DIFF
--- a/services/web/src/lib/timezone.js
+++ b/services/web/src/lib/timezone.js
@@ -4,9 +4,10 @@
  */
 
 import { writable, derived } from 'svelte/store';
+import { browser } from '$app/environment';
 
 function detectTimezone() {
-	if (typeof window === 'undefined') return 'local';
+	if (!browser) return 'UTC';  // SSR: always render as UTC for consistency
 	try {
 		const saved = localStorage.getItem('mh-timezone');
 		if (saved) return saved;
@@ -16,6 +17,14 @@ function detectTimezone() {
 
 /** 'local' = browser timezone, 'UTC' = force UTC */
 export const timezone = writable(detectTimezone());
+
+// Force store re-evaluation after hydration so client re-renders timestamps
+if (browser) {
+	// Micro-tick ensures this runs after Svelte hydration
+	queueMicrotask(() => {
+		timezone.update(v => v);
+	});
+}
 
 export function setTimezone(tz) {
 	timezone.set(tz);


### PR DESCRIPTION
## Root Cause Found

The timezone fix (appending Z to timestamps) was working in the code — confirmed both server and client bundles contain the normalizeUtcTimestamp function. But timestamps were STILL wrong.

**The real bug:** SSR hydration mismatch.

1. Server renders page with `timezone` store = `'local'` (on a UTC server, 'local' = UTC)
2. Server formats timestamps as UTC (e.g., 14:18)
3. Client hydrates with `timezone` store = `'local'` (from localStorage or default)
4. **Since the store value is the same string (`'local'`), Svelte's derived store doesn't recompute**
5. Timestamps stay at server-rendered UTC values, never re-rendered with browser's actual locale

Result: User in UTC+8 sees UTC times labeled as 'Local', and UTC mode subtracts another 8 hours.

## Fix

- SSR now explicitly returns `'UTC'` (via `browser` check from `$app/environment`) instead of `'local'`
- After hydration, `queueMicrotask(() => timezone.update(v => v))` forces the store to re-notify subscribers
- This ensures `formatTime` derived store recomputes with the actual browser locale/timezone
- Clean separation: server always renders UTC, client takes over with user's preference

## Files Changed
- `src/lib/timezone.js` — SSR-safe timezone detection + forced hydration re-render