### PR TITLE
fix(web): client-only timestamps — nuclear fix for SSR hydration

### DIFF
--- a/services/web/src/lib/Time.svelte
+++ b/services/web/src/lib/Time.svelte
@@ -1,0 +1,19 @@
+<script>
+	/**
+	 * Client-only timestamp renderer.
+	 * Bypasses SSR hydration issues by only formatting timestamps after mount.
+	 * SSR renders nothing; client renders correctly localized time.
+	 */
+	import { onMount } from 'svelte';
+	import { formatTime } from '$lib/timezone';
+
+	let { timestamp } = $props();
+	let display = $state('');
+
+	onMount(() => {
+		const unsub = formatTime.subscribe(fn => {
+			display = fn(timestamp);
+		});
+		return unsub;
+	});
+</script>{display}

--- a/services/web/src/routes/+page.svelte
+++ b/services/web/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 	import AnimatedCount from '$lib/AnimatedCount.svelte';
 	import { t } from '$lib/i18n';
 	import { formatTime } from '$lib/timezone';
+	import Time from '$lib/Time.svelte';
 	import { getMessagesCount, getMessages, getUsers, getRooms } from '$lib/api.js';
 	import { onMount } from 'svelte';
 
@@ -124,7 +125,7 @@
 									{msg.sender?.display_name || msg.sender_id}
 								</a>
 								<time class="text-xs opacity-50 ml-2">
-									{$formatTime(msg.timestamp)}
+									<Time timestamp={msg.timestamp} />
 								</time>
 							</div>
 							<div class="chat-bubble chat-bubble-primary text-sm">{msg.content}</div>

--- a/services/web/src/routes/analytics/+page.svelte
+++ b/services/web/src/routes/analytics/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { t } from '$lib/i18n';
 	import { formatTime, normalizeUtcTimestamp } from '$lib/timezone';
+	import Time from '$lib/Time.svelte';
 
 	let { data } = $props();
 
@@ -363,7 +364,7 @@
 								<tr>
 									<td class="text-xs">{row.room_id ?? ''}</td>
 									<td class="text-xs">{row.sender_id ?? ''}</td>
-									<td class="text-xs opacity-60">{row.timestamp ? $formatTime(row.timestamp) : ''}</td>
+									<td class="text-xs opacity-60">{#if row.timestamp}<Time timestamp={row.timestamp} />{/if}</td>
 								</tr>
 							{/each}
 						</tbody>

--- a/services/web/src/routes/messages/+page.svelte
+++ b/services/web/src/routes/messages/+page.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { t } from '$lib/i18n';
 	import { formatTime } from '$lib/timezone';
+	import Time from '$lib/Time.svelte';
 
 	let { data } = $props();
 	let searchInput = $state(data.query ?? '');
@@ -109,7 +110,7 @@
 						{msg.sender?.display_name || msg.sender_id}
 					</a>
 					<time class="text-xs opacity-50 ml-2">
-						{$formatTime(msg.timestamp)}
+						<Time timestamp={msg.timestamp} />
 					</time>
 				</div>
 				<div class="chat-bubble">{msg.content}</div>

--- a/services/web/src/routes/rooms/[id]/+page.svelte
+++ b/services/web/src/routes/rooms/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { t } from '$lib/i18n';
 	import { formatTime } from '$lib/timezone';
+	import Time from '$lib/Time.svelte';
 
 	let { data } = $props();
 
@@ -45,7 +46,7 @@
 						{msg.sender?.display_name || msg.sender_id}
 					</a>
 					<time class="text-xs opacity-50 ml-2">
-						{$formatTime(msg.timestamp)}
+						<Time timestamp={msg.timestamp} />
 					</time>
 				</div>
 				<div class="chat-bubble chat-bubble-primary">{msg.content}</div>

--- a/services/web/src/routes/users/[id]/+page.svelte
+++ b/services/web/src/routes/users/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { t } from '$lib/i18n';
 	import { formatTime } from '$lib/timezone';
+	import Time from '$lib/Time.svelte';
 
 	let { data } = $props();
 
@@ -45,7 +46,7 @@
 				<div class="chat-header">
 					<span class="font-medium">{displayName}</span>
 					<time class="text-xs opacity-50 ml-2">
-						{$formatTime(msg.timestamp)}
+						<Time timestamp={msg.timestamp} />
 					</time>
 				</div>
 				<div class="chat-bubble chat-bubble-secondary">{msg.content}</div>


### PR DESCRIPTION
## Why PR #54 and #55 didn't work

Svelte 5's hydration **claims SSR DOM text nodes without re-validating their content**. Even when:
- Store values change after mount (PR #54: `queueMicrotask`)
- A tick store forces derived recomputation (PR #55: `_hydrated` 0→1)

The SSR-rendered UTC timestamps stay in the DOM because Svelte never compares the computed client value with the existing text.

## The fix

New `<Time>` component that **only renders on the client**:

```svelte
<script>
  import { onMount } from 'svelte';
  import { formatTime } from '$lib/timezone';
  let { timestamp } = $props();
  let display = $state('');
  onMount(() => {
    const unsub = formatTime.subscribe(fn => {
      display = fn(timestamp);
    });
    return unsub;
  });
</script>
{display}
```

- **SSR**: Renders empty string (no `onMount` on server)
- **Client**: `onMount` fires, subscribes to `formatTime` store, renders correct local time
- **Timezone toggle**: Subscription reacts to store changes, display updates

All 5 pages updated: `{$formatTime(msg.timestamp)}` → `<Time timestamp={msg.timestamp} />`

## Trade-off

Timestamps briefly blank during hydration (~0-50ms). This is imperceptible but technically a flash of empty content. Worth it for correct timezone display.