### PR TITLE
fix: add trailing newline to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,4 +201,3 @@ jobs:
           ${{ secrets.DOCKERHUB_USERNAME }}/matrix-historian-web:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
-


### PR DESCRIPTION
ci.yml was missing a trailing newline, causing `end-of-file-fixer` pre-commit hook to fail.