### PR TITLE
fix: production compose image references

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -44,7 +44,7 @@ services:
       - historian-network-production
 
   bot:
-    image: ${BOT_IMAGE:-${DOCKERHUB_USERNAME:-weepingdogel}/matrix-historian-bot:latest}
+    image: ${BOT_IMAGE:-weepingdogel/matrix-historian-bot:latest}
     container_name: matrix-historian-bot-production
     environment:
       - MATRIX_HOMESERVER=${MATRIX_HOMESERVER}
@@ -73,7 +73,7 @@ services:
       - bot_data_production:/app/data
 
   api:
-    image: ${API_IMAGE:-${DOCKERHUB_USERNAME:-weepingdogel}/matrix-historian-api:latest}
+    image: ${API_IMAGE:-weepingdogel/matrix-historian-api:latest}
     container_name: matrix-historian-api-production
     ports:
       - "${API_PORT:-8500}:8000"
@@ -101,7 +101,7 @@ services:
       - historian-network-production
 
   web:
-    image: ${WEB_IMAGE:-${DOCKERHUB_USERNAME:-weepingdogel}/matrix-historian-web:latest}
+    image: ${WEB_IMAGE:-weepingdogel/matrix-historian-web:latest}
     container_name: matrix-historian-web-production
     ports:
       - "${WEB_PORT:-3000}:3000"


### PR DESCRIPTION
docker-compose 不支持嵌套变量 `${BOT_IMAGE:-${DOCKERHUB_USERNAME:-weepingdogel}/...}`，导致 `invalid reference format`。

改成直接 `weepingdogel/matrix-historian-{bot,api,web}:latest`。