### PR TITLE
fix: timestamps not updating when switching rooms

### DIFF
--- a/services/web/src/lib/Time.svelte
+++ b/services/web/src/lib/Time.svelte
@@ -3,17 +3,26 @@
 	 * Client-only timestamp renderer.
 	 * Bypasses SSR hydration issues by only formatting timestamps after mount.
 	 * SSR renders nothing; client renders correctly localized time.
+	 *
+	 * Uses $effect to re-render when timestamp prop or formatTime store changes.
 	 */
 	import { onMount } from 'svelte';
 	import { formatTime } from '$lib/timezone';
 
 	let { timestamp } = $props();
+	let mounted = $state(false);
 	let display = $state('');
 
 	onMount(() => {
-		const unsub = formatTime.subscribe(fn => {
-			display = fn(timestamp);
-		});
-		return unsub;
+		mounted = true;
+	});
+
+	$effect(() => {
+		if (mounted) {
+			const unsub = formatTime.subscribe(fn => {
+				display = fn(timestamp);
+			});
+			return unsub;
+		}
 	});
 </script>{display}


### PR DESCRIPTION
## Bug
When switching rooms in the message search page, timestamps stayed the same as the initial 'All Rooms' view. Only correct after a full page refresh.

## Cause
`Time.svelte` used `onMount` which captured the `timestamp` prop in a closure at mount time. When SvelteKit reused the component with new data (different room), the prop changed but the closure still used the old value.

## Fix
Replaced `onMount` subscription with `$effect()` which re-runs whenever `timestamp` prop changes, while keeping the `mounted` guard to avoid SSR hydration issues.