### PR TITLE
fix: use docker compose v2 in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,14 +31,14 @@ jobs:
             git pull origin main
 
             # Pull new images from Docker Hub
-            docker-compose -f docker-compose.production.yml pull bot api web
+            docker compose -f docker-compose.production.yml pull bot api web
 
             # Start all services (ensures db and minio are running)
-            docker-compose -f docker-compose.production.yml up -d
+            docker compose -f docker-compose.production.yml up -d
 
             # Wait and check health
             echo "Waiting for services to start..."
             sleep 15
 
             echo "Service status:"
-            docker-compose -f docker-compose.production.yml ps
+            docker compose -f docker-compose.production.yml ps


### PR DESCRIPTION
docker-compose v1 (1.29.2) 有个已知 bug：`KeyError: ContainerConfig`，和新版 Docker Engine 不兼容。

改成 `docker compose`（v2 插件）。

服务器上需要先装：
```bash
sudo apt-get update && sudo apt-get install docker-compose-plugin
```