### PR TITLE
feat: integrate missing analytics endpoints

### DIFF
--- a/services/web/src/lib/api.js
+++ b/services/web/src/lib/api.js
@@ -163,24 +163,29 @@ export function getActivityHeatmap(opts = {}, fetchFn = fetch) {
 	return request(`${BASE}/analytics/activity-heatmap`, { days, room_id }, fetchFn);
 }
 
-export function getSentiment(fetchFn = fetch) {
-	return request(`${BASE}/analytics/sentiment`, {}, fetchFn);
+export function getSentiment(opts = {}, fetchFn = fetch) {
+	const { days, room_id } = opts;
+	return request(`${BASE}/analytics/sentiment`, { days, room_id }, fetchFn);
 }
 
-export function getTopicEvolution(fetchFn = fetch) {
-	return request(`${BASE}/analytics/topic-evolution`, {}, fetchFn);
+export function getTopicEvolution(opts = {}, fetchFn = fetch) {
+	const { days, room_id } = opts;
+	return request(`${BASE}/analytics/topic-evolution`, { days, room_id }, fetchFn);
 }
 
-export function getAiAnalysis(fetchFn = fetch) {
-	return request(`${BASE}/analytics/ai-analysis`, {}, fetchFn);
+export function getAiAnalysis(opts = {}, fetchFn = fetch) {
+	const { days, room_id, analysis_type } = opts;
+	return request(`${BASE}/analytics/ai-analysis`, { days, room_id, analysis_type }, fetchFn);
 }
 
-export function getContentAnalysis(fetchFn = fetch) {
-	return request(`${BASE}/analytics/content-analysis`, {}, fetchFn);
+export function getContentAnalysis(opts = {}, fetchFn = fetch) {
+	const { days, room_id } = opts;
+	return request(`${BASE}/analytics/content-analysis`, { days, room_id }, fetchFn);
 }
 
-export function getUserNetwork(fetchFn = fetch) {
-	return request(`${BASE}/analytics/user-network`, {}, fetchFn);
+export function getUserNetwork(opts = {}, fetchFn = fetch) {
+	const { days, room_id, min_weight } = opts;
+	return request(`${BASE}/analytics/user-network`, { days, room_id, min_weight }, fetchFn);
 }
 
 export function getUserHourlyActivity(opts = {}, fetchFn = fetch) {

--- a/services/web/src/lib/locales/en.json
+++ b/services/web/src/lib/locales/en.json
@@ -130,7 +130,20 @@
 		"userHourlyActivity": "User Hourly Activity",
 		"userHourlyDesc": "Messages per user by hour (top 10 users)",
 		"showingUsers": "Showing {count} users over {days} days",
-		"filteredByRoom": "Filtered by room: {room}"
+		"filteredByRoom": "Filtered by room: {room}",
+		"sentimentTitle": "Sentiment Analysis",
+		"confidence": "Confidence",
+		"contentAnalysisTitle": "Content Analysis",
+		"word": "Word",
+		"count": "Count",
+		"userNetworkTitle": "User Network",
+		"userNetworkDesc": "Interaction connections between users",
+		"source": "Source",
+		"target": "Target",
+		"weight": "Weight",
+		"topicEvolutionTitle": "Topic Evolution",
+		"trend": "Trend",
+		"topic": "Topic"
 	},
 	"timezone": {
 		"label": "Timezone",

--- a/services/web/src/lib/locales/zh-CN.json
+++ b/services/web/src/lib/locales/zh-CN.json
@@ -130,7 +130,20 @@
 		"userHourlyActivity": "用户每小时活动",
 		"userHourlyDesc": "每位用户按小时的消息数（前 10 名）",
 		"showingUsers": "显示 {count} 位用户，共 {days} 天",
-		"filteredByRoom": "按房间筛选：{room}"
+		"filteredByRoom": "按房间筛选：{room}",
+		"sentimentTitle": "情感分析",
+		"confidence": "置信度",
+		"contentAnalysisTitle": "内容分析",
+		"word": "词语",
+		"count": "次数",
+		"userNetworkTitle": "用户关系网络",
+		"userNetworkDesc": "用户之间的互动连接关系",
+		"source": "发起方",
+		"target": "接收方",
+		"weight": "互动次数",
+		"topicEvolutionTitle": "话题演变",
+		"trend": "趋势",
+		"topic": "话题"
 	},
 	"timezone": {
 		"label": "时区",

--- a/services/web/src/routes/analytics/+page.server.js
+++ b/services/web/src/routes/analytics/+page.server.js
@@ -2,7 +2,8 @@ import {
 	getMessageStats, getUserActivity, getRoomActivity,
 	getAnalyticsOverview, getWordcloud, getActivityHeatmap,
 	getTrends, getInteractions, getMessagesCount, getRooms, getUsers,
-	getUserHourlyActivity
+	getUserHourlyActivity, getSentiment, getContentAnalysis,
+	getUserNetwork, getTopicEvolution
 } from '$lib/api.js';
 
 export async function load({ fetch, url }) {
@@ -11,7 +12,7 @@ export async function load({ fetch, url }) {
 	const room_id = url.searchParams.get('room_id') || null;
 
 	try {
-		const [msgStats, userActivity, roomActivity, overview, wordcloud, heatmap, trends, interactions, countData, rooms, users, userHourly] = await Promise.all([
+		const [msgStats, userActivity, roomActivity, overview, wordcloud, heatmap, trends, interactions, countData, rooms, users, userHourly, sentiment, contentAnalysis, userNetwork, topicEvolution] = await Promise.all([
 			getMessageStats(days, fetch).catch(() => ({ stats: [] })),
 			getUserActivity(10, fetch).catch(() => ({ users: [] })),
 			getRoomActivity(10, fetch).catch(() => ({ rooms: [] })),
@@ -23,7 +24,11 @@ export async function load({ fetch, url }) {
 			getMessagesCount({}, fetch).catch(() => ({ total: 0 })),
 			getRooms({ limit: 100000 }, fetch).catch(() => []),
 			getUsers({ limit: 100000 }, fetch).catch(() => []),
-			getUserHourlyActivity({ days, room_id, limit: 10 }, fetch).catch(() => ({ users: [], hours: [], days: 7, user_count: 0 }))
+			getUserHourlyActivity({ days, room_id, limit: 10 }, fetch).catch(() => ({ users: [], hours: [], days: 7, user_count: 0 })),
+			getSentiment({ days, room_id }, fetch).catch(() => null),
+			getContentAnalysis({ days, room_id }, fetch).catch(() => null),
+			getUserNetwork({ days, room_id }, fetch).catch(() => null),
+			getTopicEvolution({ days, room_id }, fetch).catch(() => null)
 		]);
 
 		// Compute totals from count endpoint and list lengths
@@ -59,7 +64,11 @@ export async function load({ fetch, url }) {
 			room_id,
 			rooms: Array.isArray(rooms) ? rooms : [],
 			interactions: interactions.interactions ?? [],
-			userHourlyActivity: userHourly
+			userHourlyActivity: userHourly,
+			sentiment,
+			contentAnalysis,
+			userNetwork,
+			topicEvolution
 		};
 	} catch (e) {
 		console.error('Analytics load error:', e);
@@ -73,6 +82,7 @@ export async function load({ fetch, url }) {
 			rooms: [],
 			interactions: [],
 			userHourlyActivity: { users: [], hours: [], days: 7, user_count: 0 },
+			sentiment: null, contentAnalysis: null, userNetwork: null, topicEvolution: null,
 			error: e.message
 		};
 	}

--- a/services/web/src/routes/analytics/+page.svelte
+++ b/services/web/src/routes/analytics/+page.svelte
@@ -429,4 +429,140 @@
 			</div>
 		</div>
 	{/if}
+
+	<!-- Sentiment Analysis -->
+	{#if data.sentiment}
+		<div class="card bg-base-200 shadow">
+			<div class="card-body">
+				<h3 class="card-title text-lg">{$t('analytics.sentimentTitle')}</h3>
+				<div class="flex flex-col gap-3">
+					<div class="flex items-center gap-3">
+						<span class="text-3xl">
+							{#if data.sentiment.sentiment === 'positive'}😊
+							{:else if data.sentiment.sentiment === 'negative'}😔
+							{:else}😐
+							{/if}
+						</span>
+						<div>
+							<p class="font-bold capitalize">{data.sentiment.sentiment}</p>
+							<p class="text-xs opacity-60">{$t('analytics.confidence')}: {(data.sentiment.confidence * 100).toFixed(1)}%</p>
+						</div>
+					</div>
+					{#if data.sentiment.analysis}
+						<p class="text-sm opacity-80">{data.sentiment.analysis}</p>
+					{/if}
+				</div>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Content Analysis (Word Frequency) -->
+	{#if data.contentAnalysis && data.contentAnalysis.word_frequency}
+		<div class="card bg-base-200 shadow">
+			<div class="card-body">
+				<h3 class="card-title text-lg">{$t('analytics.contentAnalysisTitle')}</h3>
+				{#if data.contentAnalysis.word_frequency.length > 0}
+					<div class="overflow-x-auto max-h-64 overflow-y-auto">
+						<table class="table table-xs">
+							<thead>
+								<tr>
+									<th>{$t('analytics.word')}</th>
+									<th class="text-right">{$t('analytics.count')}</th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each data.contentAnalysis.word_frequency.slice(0, 30) as item}
+									<tr>
+										<td class="text-sm">{item.word ?? item[0] ?? ''}</td>
+										<td class="text-sm text-right">{item.count ?? item[1] ?? 0}</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				{:else}
+					<p class="opacity-60">{$t('common.noData')}</p>
+				{/if}
+			</div>
+		</div>
+	{/if}
+
+	<!-- User Network -->
+	{#if data.userNetwork && data.userNetwork.edges && data.userNetwork.edges.length > 0}
+		<div class="card bg-base-200 shadow lg:col-span-2">
+			<div class="card-body">
+				<h3 class="card-title text-lg">{$t('analytics.userNetworkTitle')}</h3>
+				<p class="text-xs opacity-60 mb-2">{$t('analytics.userNetworkDesc')}</p>
+				<div class="flex flex-wrap gap-2 mb-4">
+					{#each data.userNetwork.nodes as node}
+						<span class="badge badge-outline">{node.id}</span>
+					{/each}
+				</div>
+				<div class="overflow-x-auto max-h-64 overflow-y-auto">
+					<table class="table table-xs">
+						<thead>
+							<tr>
+								<th>{$t('analytics.source')}</th>
+								<th>{$t('analytics.target')}</th>
+								<th class="text-right">{$t('analytics.weight')}</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each data.userNetwork.edges.sort((a, b) => b.weight - a.weight) as edge}
+								<tr>
+									<td class="text-xs">{edge.source}</td>
+									<td class="text-xs">{edge.target}</td>
+									<td class="text-xs text-right">
+										<span class="badge badge-sm badge-primary">{edge.weight}</span>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Topic Evolution -->
+	{#if data.topicEvolution}
+		<div class="card bg-base-200 shadow lg:col-span-2">
+			<div class="card-body">
+				<h3 class="card-title text-lg">{$t('analytics.topicEvolutionTitle')}</h3>
+				{#if data.topicEvolution.summary}
+					<div class="mb-4">
+						<p class="text-sm"><span class="font-medium">{$t('analytics.trend')}:</span> {data.topicEvolution.summary.trend}</p>
+						<p class="text-sm opacity-80">{data.topicEvolution.summary.analysis}</p>
+						{#if data.topicEvolution.summary.main_topics}
+							<div class="flex flex-wrap gap-1 mt-2">
+								{#each data.topicEvolution.summary.main_topics as topic}
+									<span class="badge badge-sm badge-secondary">{topic}</span>
+								{/each}
+							</div>
+						{/if}
+					</div>
+				{/if}
+				{#if data.topicEvolution.topics && data.topicEvolution.topics.length > 0}
+					<div class="overflow-x-auto max-h-48 overflow-y-auto">
+						<table class="table table-xs">
+							<thead>
+								<tr>
+									<th>{$t('analytics.topic')}</th>
+									<th>{$t('analytics.time')}</th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each data.topicEvolution.topics.slice(-30) as item}
+									<tr>
+										<td class="text-xs">{item.topic}</td>
+										<td class="text-xs opacity-60">{#if item.timestamp}<Time timestamp={item.timestamp} />{/if}</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				{/if}
+			</div>
+		</div>
+	{/if}
 </div>


### PR DESCRIPTION
## Changes

将之前后端已有但前端未使用的 analytics 端点全部接入：

### New UI Sections
- **情感分析 (Sentiment)** — 显示整体情感倾向（emoji + 置信度 + 分析文本）
- **内容分析 (Content Analysis)** — 词频表格，Top 30 高频词
- **用户关系网络 (User Network)** — 用户节点 + 互动边权重表
- **话题演变 (Topic Evolution)** — 主题摘要 + 趋势 + 时间线

### API Updates
- `getSentiment`, `getContentAnalysis`, `getUserNetwork`, `getTopicEvolution`, `getAiAnalysis` — all updated to accept `{ days, room_id }` options (was no-args before)
- All new sections respect the room selector and time range filters

### i18n
- Added 13 new keys for both `en.json` and `zh-CN.json`

### Note
This PR is based on #67 (pagination + analytics filters). Merge #67 first.