### PR TITLE
fix: resolve ruff lint errors and pages stuck on loading skeleton

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -138,28 +142,28 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 69
+        "line_number": 39
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "f3158fc40bcce81a950a85435416f52b1df4a1b8",
         "is_verified": false,
-        "line_number": 97
+        "line_number": 67
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 113
+        "line_number": 83
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 86
       }
     ],
     "MIGRATION.md": [
@@ -224,5 +228,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-19T11:09:30Z"
+  "generated_at": "2026-04-09T09:19:41Z"
 }

--- a/services/api/app/ai/analyzer.py
+++ b/services/api/app/ai/analyzer.py
@@ -28,12 +28,13 @@ class MessageAnalyzer:
             texts = [msg["content"] for msg in messages]
             combined_text = "\n".join(texts)
 
-            system_prompt = """你是一个专门进行数据分析的AI助手。请按照以下格式返回JSON：
-{
-    "sentiment": "positive/negative/neutral",
-    "confidence": 0.0-1.0,
-    "analysis": "分析总结"
-}"""
+            system_prompt = (
+                "你是一个专门进行数据分析的AI助手。"
+                "请按照以下格式返回JSON：\n"
+                '{\n    "sentiment": "positive/negative/neutral",'
+                '\n    "confidence": 0.0-1.0,'
+                '\n    "analysis": "分析总结"\n}'
+            )
             user_prompt = f"""分析以下消息的整体情感倾向：\n{combined_text}"""
 
             response = self.client.chat.completions.create(
@@ -79,7 +80,10 @@ class MessageAnalyzer:
             ]
             combined_text = "\n".join(texts)
 
-            system_prompt = "你是一个专门总结对话的AI助手。只返回JSON格式的结果，包含summary和key_points字段。"
+            system_prompt = (
+                "你是一个专门总结对话的AI助手。"
+                "只返回JSON格式的结果，包含summary和key_points字段。"
+            )
             user_prompt = f"""为这段对话生成摘要：\n{combined_text}"""
 
             response = self.client.chat.completions.create(

--- a/services/api/app/api/analytics.py
+++ b/services/api/app/api/analytics.py
@@ -56,7 +56,9 @@ def get_analytics_overview(
         }
         return set_cached(key, stats)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"分析数据获取失败: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"分析数据获取失败: {str(e)}"
+        ) from e
 
 
 @router.get("/wordcloud")
@@ -302,7 +304,9 @@ def get_wordcloud_data(
 
         return set_cached(key, {"messages": result})
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"生成词云数据失败: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"生成词云数据失败: {str(e)}"
+        ) from e
 
 
 @router.get("/interactions")
@@ -352,7 +356,9 @@ def get_message_trends(
         }
         return set_cached(key, result)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"获取消息趋势失败: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"获取消息趋势失败: {str(e)}"
+        ) from e
 
 
 @router.get("/content-analysis")
@@ -407,7 +413,9 @@ def get_user_network(
             ],
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"分析用户网络失败: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"分析用户网络失败: {str(e)}"
+        ) from e
 
 
 @router.get("/sentiment")
@@ -445,7 +453,7 @@ async def analyze_sentiment(
         }
         return set_cached(key, result)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @router.get("/activity-heatmap")
@@ -478,7 +486,9 @@ async def get_activity_heatmap(
         }
         return set_cached(key, result)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"生成活动热力图失败: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"生成活动热力图失败: {str(e)}"
+        ) from e
 
 
 @router.get("/topic-evolution")
@@ -522,7 +532,7 @@ async def analyze_topic_evolution(
         }
         return set_cached(key, result)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 def analyze_single_topic(text: str) -> str:
@@ -596,7 +606,9 @@ async def get_ai_analysis(
             },
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"AI分析失败: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"AI分析失败: {str(e)}"
+        ) from e
 
 
 @router.get("/user-hourly-activity")
@@ -650,7 +662,7 @@ async def get_user_hourly_activity(
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"获取用户每小时活动数据失败: {str(e)}"
-        )
+        ) from e
 
 
 @router.get("/analytics-health")

--- a/services/api/app/api/analytics.py
+++ b/services/api/app/api/analytics.py
@@ -606,9 +606,7 @@ async def get_ai_analysis(
             },
         }
     except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"AI分析失败: {str(e)}"
-        ) from e
+        raise HTTPException(status_code=500, detail=f"AI分析失败: {str(e)}") from e
 
 
 @router.get("/user-hourly-activity")

--- a/services/api/app/api/media.py
+++ b/services/api/app/api/media.py
@@ -127,7 +127,9 @@ def get_media_metadata(media_id: str, db: Session = Depends(get_db)):
         return MediaWithUrl(**media_dict)
     except Exception as e:
         logger.error(f"Error generating presigned URL: {str(e)}")
-        raise HTTPException(status_code=500, detail="Error generating download URL")
+        raise HTTPException(
+            status_code=500, detail="Error generating download URL"
+        ) from e
 
 
 @router.get("/{media_id}/download")
@@ -164,4 +166,6 @@ def download_media(
             )
     except Exception as e:
         logger.error(f"Error downloading media: {str(e)}")
-        raise HTTPException(status_code=500, detail="Error downloading media")
+        raise HTTPException(
+            status_code=500, detail="Error downloading media"
+        ) from e

--- a/services/api/app/api/media.py
+++ b/services/api/app/api/media.py
@@ -166,6 +166,4 @@ def download_media(
             )
     except Exception as e:
         logger.error(f"Error downloading media: {str(e)}")
-        raise HTTPException(
-            status_code=500, detail="Error downloading media"
-        ) from e
+        raise HTTPException(status_code=500, detail="Error downloading media") from e

--- a/services/api/app/api/routes.py
+++ b/services/api/app/api/routes.py
@@ -290,4 +290,6 @@ def get_avatar(
 
         return RedirectResponse(url=url)
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error fetching avatar: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Error fetching avatar: {str(e)}"
+        ) from e

--- a/services/web/src/routes/analytics/+page.svelte
+++ b/services/web/src/routes/analytics/+page.svelte
@@ -75,7 +75,7 @@
 		}
 	}
 
-	let lastFetchKey = '';
+	let lastFetchKey = null;
 	$effect(() => {
 		const key = `${data.days}|${data.room_id}|${data.interval}`;
 		if (key === lastFetchKey) return;

--- a/services/web/src/routes/media/+page.svelte
+++ b/services/web/src/routes/media/+page.svelte
@@ -29,7 +29,7 @@
 		}
 	}
 
-	let lastFetchKey = '';
+	let lastFetchKey = null;
 	$effect(() => {
 		const key = `${data.skip}|${data.mimeFilter}`;
 		if (key === lastFetchKey) return;

--- a/services/web/src/routes/messages/+page.svelte
+++ b/services/web/src/routes/messages/+page.svelte
@@ -39,7 +39,7 @@
 		}
 	}
 
-	let lastFetchKey = '';
+	let lastFetchKey = null;
 	$effect(() => {
 		const key = `${data.query}|${data.room_id}|${data.user_id}|${data.start_date}|${data.end_date}|${data.sort}`;
 		if (key === lastFetchKey) return;

--- a/services/web/src/routes/rooms/+page.svelte
+++ b/services/web/src/routes/rooms/+page.svelte
@@ -42,7 +42,7 @@
 		}
 	}
 
-	let lastFetchKey = '';
+	let lastFetchKey = null;
 	$effect(() => {
 		const key = `${data.query}`;
 		if (key === lastFetchKey) return;

--- a/services/web/src/routes/rooms/[id]/+page.svelte
+++ b/services/web/src/routes/rooms/[id]/+page.svelte
@@ -36,7 +36,7 @@
 		}
 	}
 
-	let lastFetchKey = '';
+	let lastFetchKey = null;
 	$effect(() => {
 		const key = `${data.roomId}|${data.skip}`;
 		if (key === lastFetchKey) return;

--- a/services/web/src/routes/users/+page.svelte
+++ b/services/web/src/routes/users/+page.svelte
@@ -41,7 +41,7 @@
 		}
 	}
 
-	let lastFetchKey = '';
+	let lastFetchKey = null;
 	$effect(() => {
 		const key = `${data.query}`;
 		if (key === lastFetchKey) return;

--- a/services/web/src/routes/users/[id]/+page.svelte
+++ b/services/web/src/routes/users/[id]/+page.svelte
@@ -38,7 +38,7 @@
 		}
 	}
 
-	let lastFetchKey = '';
+	let lastFetchKey = null;
 	$effect(() => {
 		const key = `${data.userId}|${data.skip}`;
 		if (key === lastFetchKey) return;


### PR DESCRIPTION
Lint fixes:
- Break long lines in analyzer.py (E501)
- Add exception chaining `from e` to all raise in except blocks (B904) across analytics.py, media.py, routes.py

Loading fix:
- Initialize lastFetchKey to null instead of '' on all 7 pages
- When query param is empty, key computed to '' which matched the initial lastFetchKey='', causing the guard to skip the first fetch and leaving pageLoading=true forever