### PR TITLE
feat: replace pagination with infinite scroll and use client-side fil…

### DIFF
--- a/services/web/src/routes/media/+page.svelte
+++ b/services/web/src/routes/media/+page.svelte
@@ -223,7 +223,6 @@
 	</div>
 
 	<InfiniteScroll {loading} {hasMore} onLoadMore={loadMore} />
- {/if}
-
 {/if}
 
+{/if}

--- a/services/web/src/routes/media/+page.svelte
+++ b/services/web/src/routes/media/+page.svelte
@@ -223,6 +223,7 @@
 	</div>
 
 	<InfiniteScroll {loading} {hasMore} onLoadMore={loadMore} />
-{/if}
+ {/if}
 
 {/if}
+

--- a/services/web/src/routes/media/+page.svelte
+++ b/services/web/src/routes/media/+page.svelte
@@ -1,10 +1,18 @@
 <script>
+	import { goto } from '$app/navigation';
 	import { t } from '$lib/i18n';
 	import Skeleton from '$lib/Skeleton.svelte';
+	import InfiniteScroll from '$lib/InfiniteScroll.svelte';
 	import { getMedia, getMediaStats } from '$lib/api.js';
 
 	let { data } = $props();
 	let pageLoading = $state(true);
+
+	// Accumulated media for infinite scroll
+	let allMedia = $state([]);
+	let currentSkip = $state(0);
+	let hasMore = $state(false);
+	let loading = $state(false);
 
 	async function fetchMedia() {
 		pageLoading = true;
@@ -13,15 +21,19 @@
 				getMedia({ skip: data.skip, limit: data.limit, mime_type: data.mimeFilter || undefined }),
 				getMediaStats().catch(() => null)
 			]);
+			const total = result.total ?? 0;
 			data = {
 				...data,
 				media: result.media ?? [],
-				total: result.total ?? 0,
+				total,
 				hasMore: result.has_more ?? false,
 				nextSkip: result.next_skip,
 				stats,
 				_loading: false
 			};
+			allMedia = [...(result.media ?? [])];
+			currentSkip = result.media?.length ?? 0;
+			hasMore = total > data.limit;
 		} catch (e) {
 			console.error('Media fetch error:', e);
 		} finally {
@@ -37,8 +49,30 @@
 		fetchMedia();
 	});
 
-	let currentPage = $derived(Math.floor(data.skip / data.limit) + 1);
-	let totalPages = $derived(Math.ceil(data.total / data.limit) || 1);
+	async function loadMore() {
+		if (loading || !hasMore) return;
+		loading = true;
+		try {
+			const params = new URLSearchParams();
+			params.set('skip', String(currentSkip));
+			params.set('limit', String(data.limit));
+			if (data.mimeFilter) params.set('mime_type', data.mimeFilter);
+
+			const res = await fetch(`/api/v1/media?${params.toString()}`);
+			if (!res.ok) throw new Error(`API ${res.status}`);
+			const result = await res.json();
+
+			const newMedia = result.media ?? [];
+			allMedia = [...allMedia, ...newMedia];
+			currentSkip += newMedia.length;
+			hasMore = result.has_more ?? false;
+		} catch (e) {
+			console.error('Load more error:', e);
+			hasMore = false;
+		} finally {
+			loading = false;
+		}
+	}
 
 	function isImage(mime) {
 		return mime && mime.startsWith('image/');
@@ -67,6 +101,10 @@
 		if (mime.startsWith('text/')) return '📝';
 		if (mime.includes('pdf')) return '📕';
 		return '📄';
+	}
+
+	function setFilter(value) {
+		goto(`/media?type=${value}`);
 	}
 
 	let filterItems = $derived([
@@ -121,27 +159,27 @@
 <!-- Filter tabs -->
 <div class="tabs tabs-box mb-6">
 	{#each filterItems as f}
-		<a
-			href="/media?type={f.value}"
+		<button
 			class="tab"
 			class:tab-active={data.mimeFilter === f.value}
+			onclick={() => setFilter(f.value)}
 		>
 			<span class="mr-1">{f.icon}</span>
 			{f.label}
-		</a>
+		</button>
 	{/each}
 </div>
 
 <div class="flex justify-between items-center mb-4">
 	<p class="text-sm opacity-60">{$t('media.fileCount', { count: data.total.toLocaleString() })}</p>
-	<p class="text-sm opacity-60">{$t('common.page')} {currentPage} {$t('common.of')} {totalPages}</p>
+	<p class="text-sm opacity-60">{allMedia.length} / {data.total}</p>
 </div>
 
-{#if data.media.length === 0}
+{#if allMedia.length === 0 && !loading}
 	<p class="opacity-60">{$t('media.noMedia')}</p>
 {:else}
 	<div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-		{#each data.media as m}
+		{#each allMedia as m}
 			<div class="card bg-base-200 shadow-sm hover:shadow-md transition-shadow">
 				<figure class="h-32 bg-base-300 flex items-center justify-center overflow-hidden relative">
 					{#if isImage(m.mime_type)}
@@ -184,20 +222,7 @@
 		{/each}
 	</div>
 
-	<!-- Pagination -->
-	<div class="flex items-center gap-2 mt-6 justify-center">
-		{#if data.skip > 0}
-			<a href="/media?skip={Math.max(0, data.skip - data.limit)}&type={data.mimeFilter}" class="btn btn-outline btn-sm">
-				{$t('common.previous')}
-			</a>
-		{/if}
-		<span class="text-sm opacity-60">{$t('common.page')} {currentPage} {$t('common.of')} {totalPages}</span>
-		{#if data.hasMore}
-			<a href="/media?skip={data.nextSkip}&type={data.mimeFilter}" class="btn btn-outline btn-sm">
-				{$t('common.next')}
-			</a>
-		{/if}
-	</div>
+	<InfiniteScroll {loading} {hasMore} onLoadMore={loadMore} />
 {/if}
 
 {/if}

--- a/services/web/src/routes/rooms/[id]/+page.svelte
+++ b/services/web/src/routes/rooms/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import { formatTime } from '$lib/timezone';
 	import Time from '$lib/Time.svelte';
 	import Skeleton from '$lib/Skeleton.svelte';
+	import InfiniteScroll from '$lib/InfiniteScroll.svelte';
 	import { getRoomMessages, getMessagesCount } from '$lib/api.js';
 
 	let { data } = $props();
@@ -12,23 +13,30 @@
 		data.messages.length > 0 ? (data.messages[0].room?.name || data.roomId) : data.roomId
 	);
 
-	let currentPage = $derived(Math.floor(data.skip / data.limit) + 1);
-	let totalPages = $derived(Math.ceil(data.total / data.limit) || 1);
+	// Accumulated messages for infinite scroll
+	let allMessages = $state([]);
+	let currentSkip = $state(0);
+	let hasMore = $state(false);
+	let loading = $state(false);
 
 	async function fetchRoomMessages() {
 		pageLoading = true;
 		try {
 			const [messages, countData] = await Promise.all([
-				getRoomMessages(data.roomId, { skip: data.skip, limit: data.limit }),
+				getRoomMessages(data.roomId, { skip: 0, limit: data.limit }),
 				getMessagesCount({ room_id: data.roomId }).catch(() => ({ total: 0 }))
 			]);
+			const total = countData.total ?? 0;
 			data = {
 				...data,
 				messages,
-				total: countData.total ?? 0,
+				total,
 				hasMore: messages.length === data.limit,
 				_loading: false
 			};
+			allMessages = [...messages];
+			currentSkip = messages.length;
+			hasMore = total > data.limit;
 		} catch (e) {
 			console.error('Room detail fetch error:', e);
 		} finally {
@@ -38,11 +46,34 @@
 
 	let lastFetchKey = null;
 	$effect(() => {
-		const key = `${data.roomId}|${data.skip}`;
+		const key = data.roomId;
 		if (key === lastFetchKey) return;
 		lastFetchKey = key;
 		fetchRoomMessages();
 	});
+
+	async function loadMore() {
+		if (loading || !hasMore) return;
+		loading = true;
+		try {
+			const params = new URLSearchParams();
+			params.set('skip', String(currentSkip));
+			params.set('limit', String(data.limit));
+
+			const res = await fetch(`/api/v1/rooms/${encodeURIComponent(data.roomId)}/messages?${params.toString()}`);
+			if (!res.ok) throw new Error(`API ${res.status}`);
+			const newMessages = await res.json();
+
+			allMessages = [...allMessages, ...newMessages];
+			currentSkip += newMessages.length;
+			hasMore = newMessages.length >= data.limit;
+		} catch (e) {
+			console.error('Load more error:', e);
+			hasMore = false;
+		} finally {
+			loading = false;
+		}
+	}
 </script>
 
 <svelte:head>
@@ -64,20 +95,24 @@
 		<Skeleton variant="chat" count={5} />
 	</div>
 {:else}
-	<p class="text-sm opacity-60 mb-6">
-		{$t('rooms.messageCount', { count: data.total.toLocaleString() })}
-		{#if data.total > 0}· {$t('common.page')} {currentPage} {$t('common.of')} {totalPages}{/if}
-	</p>
+	<div class="flex justify-between items-center mb-6">
+		<p class="text-sm opacity-60">
+			{$t('rooms.messageCount', { count: data.total.toLocaleString() })}
+		</p>
+		<p class="text-sm opacity-60">
+			{allMessages.length} / {data.total}
+		</p>
+	</div>
 
 	{#if data.error}
 		<div class="alert alert-warning mb-4"><span>{$t('common.error', { error: data.error })}</span></div>
 	{/if}
 
-	{#if data.messages.length === 0}
+	{#if allMessages.length === 0 && !loading}
 		<p class="opacity-60">{$t('messages.noMessages')}</p>
 	{:else}
 		<div class="space-y-1">
-			{#each data.messages as msg}
+			{#each allMessages as msg}
 				<div class="chat chat-start">
 					<div class="chat-header">
 						<a href="/users/{encodeURIComponent(msg.sender_id)}" class="link link-hover font-medium">
@@ -92,18 +127,6 @@
 			{/each}
 		</div>
 
-		<div class="flex items-center gap-2 mt-6 justify-center">
-			{#if data.skip > 0}
-				<a href="/rooms/{encodeURIComponent(data.roomId)}?skip={Math.max(0, data.skip - data.limit)}" class="btn btn-outline btn-sm">
-					{$t('common.previous')}
-				</a>
-			{/if}
-			<span class="text-sm opacity-60">{$t('common.page')} {currentPage} {$t('common.of')} {totalPages}</span>
-			{#if data.hasMore}
-				<a href="/rooms/{encodeURIComponent(data.roomId)}?skip={data.skip + data.limit}" class="btn btn-outline btn-sm">
-					{$t('common.next')}
-				</a>
-			{/if}
-		</div>
+		<InfiniteScroll {loading} {hasMore} onLoadMore={loadMore} />
 	{/if}
 {/if}

--- a/services/web/src/routes/rooms/[id]/+page.svelte
+++ b/services/web/src/routes/rooms/[id]/+page.svelte
@@ -128,5 +128,6 @@
 		</div>
 
 		<InfiniteScroll {loading} {hasMore} onLoadMore={loadMore} />
-	{/if}
+ {/if}
 {/if}
+

--- a/services/web/src/routes/rooms/[id]/+page.svelte
+++ b/services/web/src/routes/rooms/[id]/+page.svelte
@@ -128,6 +128,5 @@
 		</div>
 
 		<InfiniteScroll {loading} {hasMore} onLoadMore={loadMore} />
- {/if}
+	{/if}
 {/if}
-

--- a/services/web/src/routes/users/[id]/+page.svelte
+++ b/services/web/src/routes/users/[id]/+page.svelte
@@ -133,5 +133,6 @@
 		</div>
 
 		<InfiniteScroll {loading} {hasMore} onLoadMore={loadMore} />
-	{/if}
+ {/if}
 {/if}
+

--- a/services/web/src/routes/users/[id]/+page.svelte
+++ b/services/web/src/routes/users/[id]/+page.svelte
@@ -133,6 +133,5 @@
 		</div>
 
 		<InfiniteScroll {loading} {hasMore} onLoadMore={loadMore} />
- {/if}
+	{/if}
 {/if}
-

--- a/services/web/src/routes/users/[id]/+page.svelte
+++ b/services/web/src/routes/users/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import { formatTime } from '$lib/timezone';
 	import Time from '$lib/Time.svelte';
 	import Skeleton from '$lib/Skeleton.svelte';
+	import InfiniteScroll from '$lib/InfiniteScroll.svelte';
 	import { getUserMessages, getMessagesCount } from '$lib/api.js';
 
 	let { data } = $props();
@@ -14,23 +15,30 @@
 			: data.userId
 	);
 
-	let currentPage = $derived(Math.floor(data.skip / data.limit) + 1);
-	let totalPages = $derived(Math.ceil(data.total / data.limit) || 1);
+	// Accumulated messages for infinite scroll
+	let allMessages = $state([]);
+	let currentSkip = $state(0);
+	let hasMore = $state(false);
+	let loading = $state(false);
 
 	async function fetchUserMessages() {
 		pageLoading = true;
 		try {
 			const [messages, countData] = await Promise.all([
-				getUserMessages(data.userId, { skip: data.skip, limit: data.limit }),
+				getUserMessages(data.userId, { skip: 0, limit: data.limit }),
 				getMessagesCount({ user_id: data.userId }).catch(() => ({ total: 0 }))
 			]);
+			const total = countData.total ?? 0;
 			data = {
 				...data,
 				messages,
-				total: countData.total ?? 0,
+				total,
 				hasMore: messages.length === data.limit,
 				_loading: false
 			};
+			allMessages = [...messages];
+			currentSkip = messages.length;
+			hasMore = total > data.limit;
 		} catch (e) {
 			console.error('User detail fetch error:', e);
 		} finally {
@@ -40,11 +48,34 @@
 
 	let lastFetchKey = null;
 	$effect(() => {
-		const key = `${data.userId}|${data.skip}`;
+		const key = data.userId;
 		if (key === lastFetchKey) return;
 		lastFetchKey = key;
 		fetchUserMessages();
 	});
+
+	async function loadMore() {
+		if (loading || !hasMore) return;
+		loading = true;
+		try {
+			const params = new URLSearchParams();
+			params.set('skip', String(currentSkip));
+			params.set('limit', String(data.limit));
+
+			const res = await fetch(`/api/v1/users/${encodeURIComponent(data.userId)}/messages?${params.toString()}`);
+			if (!res.ok) throw new Error(`API ${res.status}`);
+			const newMessages = await res.json();
+
+			allMessages = [...allMessages, ...newMessages];
+			currentSkip += newMessages.length;
+			hasMore = newMessages.length >= data.limit;
+		} catch (e) {
+			console.error('Load more error:', e);
+			hasMore = false;
+		} finally {
+			loading = false;
+		}
+	}
 </script>
 
 <svelte:head>
@@ -66,20 +97,24 @@
 		<Skeleton variant="chat" count={5} />
 	</div>
 {:else}
-	<p class="text-sm opacity-60 mb-6">
-		{$t('users.messageCount', { count: data.total.toLocaleString() })}
-		{#if data.total > 0}· {$t('common.page')} {currentPage} {$t('common.of')} {totalPages}{/if}
-	</p>
+	<div class="flex justify-between items-center mb-6">
+		<p class="text-sm opacity-60">
+			{$t('users.messageCount', { count: data.total.toLocaleString() })}
+		</p>
+		<p class="text-sm opacity-60">
+			{allMessages.length} / {data.total}
+		</p>
+	</div>
 
 	{#if data.error}
 		<div class="alert alert-warning mb-4"><span>{$t('common.error', { error: data.error })}</span></div>
 	{/if}
 
-	{#if data.messages.length === 0}
+	{#if allMessages.length === 0 && !loading}
 		<p class="opacity-60">{$t('users.noMessagesFrom')}</p>
 	{:else}
 		<div class="space-y-1">
-			{#each data.messages as msg}
+			{#each allMessages as msg}
 				<div class="chat chat-start">
 					<div class="chat-header">
 						<span class="font-medium">{displayName}</span>
@@ -97,18 +132,6 @@
 			{/each}
 		</div>
 
-		<div class="flex items-center gap-2 mt-6 justify-center">
-			{#if data.skip > 0}
-				<a href="/users/{encodeURIComponent(data.userId)}?skip={Math.max(0, data.skip - data.limit)}" class="btn btn-outline btn-sm">
-					{$t('common.previous')}
-				</a>
-			{/if}
-			<span class="text-sm opacity-60">{$t('common.page')} {currentPage} {$t('common.of')} {totalPages}</span>
-			{#if data.hasMore}
-				<a href="/users/{encodeURIComponent(data.userId)}?skip={data.skip + data.limit}" class="btn btn-outline btn-sm">
-					{$t('common.next')}
-				</a>
-			{/if}
-		</div>
+		<InfiniteScroll {loading} {hasMore} onLoadMore={loadMore} />
 	{/if}
 {/if}


### PR DESCRIPTION
…ter navigation

This commit introduces infinite scrolling for the media page, replacing the previous pagination (previous/next page links). It accumulates loaded media in a new `allMedia` state and fetches more items via the API when the user scrolls down. Filter tabs are now buttons that trigger client-side navigation using `goto` instead of full page reloads, improving responsiveness. The old pagination UI and navigation logic are removed.