### PR TITLE
refactor(bot): remove redundant media event skip in text handler

### DIFF
--- a/services/bot/app/bot.py
+++ b/services/bot/app/bot.py
@@ -230,10 +230,6 @@ class MatrixBot:
             if event.sender == self.creds.username:
                 return
 
-            # Skip text handler for events already handled as media
-            if getattr(event, "_is_media_event", False):
-                return
-
             try:
                 with SessionLocal() as db:
                     # Create or update user


### PR DESCRIPTION
Removes the conditional bypass for media events in the text handler. This streamlines event processing and eliminates redundant checks now that media routing is handled separately.