### PR TITLE
chore: add requests dependency to bot service

### DIFF
--- a/services/bot/requirements.txt
+++ b/services/bot/requirements.txt
@@ -1,4 +1,5 @@
 # Matrix Bot Service dependencies
+requests>=2.28.0
 cachetools>=5.0.0
 atomicwrites>=1.4.0
 matrix-nio==0.25.2


### PR DESCRIPTION
Add requests>=2.28.0 to services/bot/requirements.txt to support HTTP client operations in the Matrix bot service.