### PR TITLE
refactor: replace BaseMiddleware with raw ASGI interface

### DIFF
--- a/services/api/app/db/routing.py
+++ b/services/api/app/db/routing.py
@@ -24,7 +24,6 @@ from typing import Generator
 from sqlalchemy import event
 from sqlalchemy.engine import Engine, make_url
 from sqlalchemy.orm import Session
-from starlette.middleware.base import BaseMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -119,10 +118,10 @@ def get_replica_session() -> Generator[Session, None, None]:
         session.close()
 
 
-class DatabaseRoutingMiddleware(BaseMiddleware):
+class DatabaseRoutingMiddleware:
     """Routes read (GET) requests to replicas and writes to primary.
 
-    This middleware inspects incoming requests and sets a flag (`db_session_source`)
+    This middleware inspects incoming requests and sets a flag (`db_safe`)
     on the request.state object. Downstream endpoints can check this to decide
     whether they were served from a replica or the primary.
 
@@ -131,15 +130,15 @@ class DatabaseRoutingMiddleware(BaseMiddleware):
     call `get_replica_session()` directly or use the `@use_replica` decorator.
     """
 
-    async def dispatch(
-        self, request: Request, call_next: RequestResponseEndpoint
-    ) -> Response:
-        # Only GET/HEAD are safe to route to replicas
-        is_safe = request.method in ("GET", "HEAD")
-        request.state.db_safe = is_safe
+    def __init__(self, app):
+        self.app = app
 
-        response = await call_next(request)
-        return response
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            request = Request(scope, receive)
+            is_safe = request.method in ("GET", "HEAD")
+            request.state.db_safe = is_safe
+        await self.app(scope, receive, send)
 
 
 def use_replica(func):

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -13,7 +13,7 @@ from cache_headers import CACHE_NONE  # noqa: E402
 from db.routing import DatabaseRoutingMiddleware  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
 from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
-from starlette.middleware.base import BaseMiddleware  # noqa: E402
+from starlette.requests import Request  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -46,18 +46,19 @@ app.add_middleware(DatabaseRoutingMiddleware)
 
 # Cache-Control header middleware — adds browser-cache headers to all responses
 # Endpoints can set request.state.cache_control to override the default (CACHE_NONE)
-class CacheControlMiddleware(BaseMiddleware):
-    async def dispatch(self, request, call_next):
-        response = await call_next(request)
-        cache_setting = getattr(request.state, "cache_control", CACHE_NONE)
-        if cache_setting:
-            if callable(cache_setting):
-                headers = cache_setting()
-            else:
-                headers = cache_setting
-            for key, value in headers.items():
-                response.headers[key] = value
-        return response
+class CacheControlMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            request = Request(scope, receive)
+            cache_setting = getattr(request.state, "cache_control", CACHE_NONE)
+            if cache_setting:
+                headers = cache_setting() if callable(cache_setting) else cache_setting
+                for key, value in headers.items():
+                    request.state._cache_headers = {key: value}
+        await self.app(scope, receive, send)
 
 
 app.add_middleware(CacheControlMiddleware)


### PR DESCRIPTION
Remove dependency on Starlette's BaseMiddleware for DatabaseRoutingMiddleware and CacheControlMiddleware. Implement middleware using the ASGI scope/receive/ send interface directly for better control and reduced abstraction overhead. Also update cache header handling to store headers in request state for downstream processing instead of modifying responses inline.