### PR TITLE
fix: ensure cached responses return plain dicts instead of Pydantic m…

### DIFF
--- a/services/api/app/api/analytics.py
+++ b/services/api/app/api/analytics.py
@@ -1,7 +1,7 @@
 import re
 import sys
 
-sys.path.insert(0, "/app/shared")  # Still correct, base_app is under shared
+sys.path.insert(0, "/app/shared")
 from datetime import datetime, timezone  # noqa: E402
 from typing import Dict, List  # noqa: E402
 
@@ -10,7 +10,7 @@ from base_app.db.database import get_db  # noqa: E402
 from cache import cache_key, get_cached, set_cached  # noqa: E402
 from cache_headers import CACHE_LONG, cache_control  # noqa: E402
 from fastapi import APIRouter, Depends, HTTPException, Query  # noqa: E402
-from fastapi.responses import JSONResponse  # noqa: E402
+from pydantic import BaseModel  # noqa: E402
 from sqlalchemy.orm import Session  # noqa: E402
 
 router = APIRouter(prefix="/analytics", tags=["analytics"])

--- a/services/api/app/api/routes.py
+++ b/services/api/app/api/routes.py
@@ -172,10 +172,13 @@ def read_users(
     key = cache_key("list", "users", str(skip), str(limit))
     cached = get_cached("list", key)
     if cached is not None:
+        # Ensure cache returns list of dicts, not Pydantic models
+        if isinstance(cached, list) and len(cached) > 0 and hasattr(cached[0], 'model_dump'):
+            cached = [c.model_dump() for c in cached]
         return JSONResponse(content=cached, headers=cache_control(CACHE_SHORT))
 
     users = crud.get_users(db, skip=skip, limit=limit)
-    result = [UserBase.model_validate(u) for u in users]
+    result = [UserBase.model_validate(u).model_dump() for u in users]
     set_cached("list", key, result)
     return JSONResponse(content=result, headers=cache_control(CACHE_SHORT))
 
@@ -226,10 +229,13 @@ def read_rooms(
     key = cache_key("list", "rooms", str(skip), str(limit))
     cached = get_cached("list", key)
     if cached is not None:
+        # Ensure cache returns list of dicts, not Pydantic models
+        if isinstance(cached, list) and len(cached) > 0 and hasattr(cached[0], 'model_dump'):
+            cached = [c.model_dump() for c in cached]
         return JSONResponse(content=cached, headers=cache_control(CACHE_SHORT))
 
     rooms = crud.get_rooms(db, skip=skip, limit=limit)
-    result = [RoomBase.model_validate(r) for r in rooms]
+    result = [RoomBase.model_validate(r).model_dump() for r in rooms]
     set_cached("list", key, result)
     return JSONResponse(content=result, headers=cache_control(CACHE_SHORT))
 


### PR DESCRIPTION
…odels

When caching user and room list responses, Pydantic models were being stored and later retrieved from cache without serialization. This caused the cached data to contain Pydantic model instances instead of dictionaries, which could cause issues when serialized to JSON in the response. Added explicit `.model_dump()` calls after validation and cache retrieval to ensure consistent dict serialization. Also cleaned up an outdated path comment and swapped an unused JSONResponse import for BaseModel.